### PR TITLE
Fix ModelType.php for Symfony-2.8

### DIFF
--- a/Form/ChoiceList/ModelChoiceList.php
+++ b/Form/ChoiceList/ModelChoiceList.php
@@ -105,7 +105,7 @@ class ModelChoiceList extends ObjectChoiceList
             $this->identifier = $this->query->getTableMap()->getPrimaryKeys();
         }
 
-        $this->loaded = is_array($choices) || $choices instanceof \Traversable;
+        $this->loaded = (is_array($choices) && array() !== $choices) || $choices instanceof \Traversable;
 
         if ($preferred instanceof \ModelCriteria) {
             $this->preferredQuery = $preferred->mergeWith($this->query);

--- a/Form/Type/ModelType.php
+++ b/Form/Type/ModelType.php
@@ -102,7 +102,7 @@ class ModelType extends AbstractType
             'class' => null,
             'property' => null,
             'query' => null,
-            'choices' => null,
+            'choices' => array(),
             'choice_list' => $choiceList,
             'group_by' => null,
             'by_reference' => false,


### PR DESCRIPTION
Using null will raise following exception: Catchable Fatal Error: Argument 1 passed to Symfony\Component\Form\Extension\Core\Type\ChoiceType::normalizeLegacyChoices() must be of the type array, null given, called in .../vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php on line 266 and defined
